### PR TITLE
Add PyBytes_FromStringAndSize API wrapper

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -14,20 +14,20 @@ package python3
 import "C"
 import "unsafe"
 
-//Bytes : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Type
+// Bytes : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Type
 var Bytes = togo((*C.PyObject)(unsafe.Pointer(&C.PyBytes_Type)))
 
-//PyBytes_Check : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Check
+// PyBytes_Check : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Check
 func PyBytes_Check(o *PyObject) bool {
 	return C._go_PyBytes_Check(toc(o)) != 0
 }
 
-//PyBytes_CheckExact : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_CheckExact
+// PyBytes_CheckExact : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_CheckExact
 func PyBytes_CheckExact(o *PyObject) bool {
 	return C._go_PyBytes_CheckExact(toc(o)) != 0
 }
 
-//PyBytes_FromString : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromString
+// PyBytes_FromString : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromString
 func PyBytes_FromString(str string) *PyObject {
 	cstr := C.CString(str)
 	defer C.free(unsafe.Pointer(cstr))
@@ -35,29 +35,37 @@ func PyBytes_FromString(str string) *PyObject {
 	return togo(C.PyBytes_FromString(cstr))
 }
 
-//PyBytes_FromObject : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromObject
+// PyBytes_FromStringAndSize : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
+func PyBytes_FromStringAndSize(str string) *PyObject {
+	cstr := C.CString(str)
+	defer C.free(unsafe.Pointer(cstr))
+
+	return togo(C.PyBytes_FromStringAndSize(cstr, C.Py_ssize_t(len(str))))
+}
+
+// PyBytes_FromObject : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromObject
 func PyBytes_FromObject(o *PyObject) *PyObject {
 	return togo(C.PyBytes_FromObject(toc(o)))
 }
 
-//PyBytes_Size : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Size
+// PyBytes_Size : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Size
 func PyBytes_Size(o *PyObject) int {
 	return int(C.PyBytes_Size(toc(o)))
 }
 
-//PyBytes_AsString : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
+// PyBytes_AsString : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
 func PyBytes_AsString(o *PyObject) string {
-	return C.GoStringN(C.PyBytes_AsString(toc(o)), C.int(C.PyBytes_Size(toc(o)))) 
+	return C.GoStringN(C.PyBytes_AsString(toc(o)), C.int(C.PyBytes_Size(toc(o))))
 }
 
-//PyBytes_Concat : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Concat
+// PyBytes_Concat : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Concat
 func PyBytes_Concat(bytes, newpart *PyObject) *PyObject {
 	cbytes := toc(bytes)
 	C.PyBytes_Concat(&cbytes, toc(newpart))
 	return togo(cbytes)
 }
 
-//PyBytes_ConcatAndDel : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_ConcatAndDel
+// PyBytes_ConcatAndDel : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_ConcatAndDel
 func PyBytes_ConcatAndDel(bytes, newpart *PyObject) *PyObject {
 	cbytes := toc(bytes)
 	C.PyBytes_ConcatAndDel(&cbytes, toc(newpart))

--- a/import_test.go
+++ b/import_test.go
@@ -124,6 +124,13 @@ func TestExecCodeModule(t *testing.T) {
 	module := PyImport_ExecCodeModule("test_module", code)
 	assert.NotNil(t, module)
 
+	testModuleStr := PyUnicode_FromString("test_module")
+	defer testModuleStr.DecRef()
+
+	pyModule := PyImport_GetModule(testModuleStr)
+	defer pyModule.DecRef()
+
+	assert.NotNil(t, pyModule)
 }
 
 func TestExecCodeModuleEx(t *testing.T) {


### PR DESCRIPTION
Self explanatory. The existing wrapper isn't exhaustive, and this API doesn't have null-termination issues.