### PR TITLE
Fork PyBytes APIs to work on strings and bytes

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -35,7 +35,7 @@ func PyBytes_FromString(str string) *PyObject {
 	return togo(C.PyBytes_FromString(cstr))
 }
 
-// PyBytes_FromStringAndSize : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
+// PyBytes_FromStringAndSize : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromStringAndSize
 func PyBytes_FromStringAndSize(str string) *PyObject {
 	cstr := C.CString(str)
 	defer C.free(unsafe.Pointer(cstr))
@@ -70,4 +70,22 @@ func PyBytes_ConcatAndDel(bytes, newpart *PyObject) *PyObject {
 	cbytes := toc(bytes)
 	C.PyBytes_ConcatAndDel(&cbytes, toc(newpart))
 	return togo(cbytes)
+}
+
+// PyBytes_FromByteSlice uses https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromStringAndSize but with []byte
+func PyBytes_FromByteSlice(bytes []byte) *PyObject {
+	pbytes := C.CBytes(bytes)
+	defer C.free(pbytes)
+
+	cstr := (*C.char)(pbytes)
+
+	return togo(C.PyBytes_FromStringAndSize(cstr, C.Py_ssize_t(len(bytes))))
+}
+
+// PyBytes_AsByteSlice is equivalent to PyBytes_AsString but returns byte slices
+func PyBytes_AsByteSlice(o *PyObject) []byte {
+	cstr := C.PyBytes_AsString(toc(o))
+	size := C.PyBytes_Size(toc(o))
+
+	return C.GoBytes(unsafe.Pointer(cstr), C.int(size))
 }

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -84,3 +84,19 @@ func TestBytesConcatAndDel(t *testing.T) {
 
 	assert.Equal(t, s1+s2, PyBytes_AsString(bytes1))
 }
+
+func TestByteSlices(t *testing.T) {
+	Py_Initialize()
+
+	s1 := []byte("aaaaaaaa")
+	s2 := []byte("bbbbbbbb")
+
+	bytes1 := PyBytes_FromByteSlice(s1)
+	defer bytes1.DecRef()
+
+	bytes2 := PyBytes_FromByteSlice(s2)
+	defer bytes2.DecRef()
+
+	assert.Equal(t, s1, PyBytes_AsByteSlice(bytes1))
+	assert.Equal(t, s2, PyBytes_AsByteSlice(bytes2))
+}


### PR DESCRIPTION
This copies the existing PyBytes APIs that take and return strings to ones that operate on `[]byte` in Go to a Python bytes object. Go's `[]byte(s)` and `string(some_bytes)` conversions sometimes mean extra allocations and these can be costly for large values.

<!-- Notion:  https://www.notion.so/sublimesecurity/71751c8b294a47f1b99fe09ba1009f7b?pvs=4 -->